### PR TITLE
Update to Tracker 2.14.0

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="favicon.ico" />
     <title>FOI Report Download</title>
-    <!-- Snowplow starts plowing - Standalone vA.2.10.2 -->
+    <!-- Snowplow starts plowing - Standalone vE.2.14.0 -->
     <script type="text/javascript">
       ;(function(p, l, o, w, i, n, g) {
         if (!p[i]) {
@@ -32,6 +32,7 @@
       var collector = '<%=process.env.SNOWPLOW_COLLECTOR_HOST%>'
       window.snowplow('newTracker', 'rt', collector, {
         appId: 'Snowplow_standalone',
+        cookieLifetime: 86400 * 548,
         platform: 'web',
         post: true,
         forceSecureTracker: true,


### PR DESCRIPTION
The environment variables are controlled in the deployment config on Openshift, or locally.

The only change is to add a `cookieLifetime: 86400 * 548,` to the tracker code block.