### PR TITLE
Testing jenkins setup, modified row limit warning

### DIFF
--- a/client/src/components/Form.vue
+++ b/client/src/components/Form.vue
@@ -107,7 +107,7 @@
       <v-row>
         <v-col class="d-flex" cols="12">
           <v-alert type="warning" icon="mdi-alert-circle">
-            Report is limited to 5,000 results.
+            Report is limited to 5000 results.
           </v-alert>
         </v-col>
       </v-row>


### PR DESCRIPTION
This PR removes a comma from the number in the row limit warning. The purpose of this change is to provide a visual way to see the update when bringing in the change with jenkins. 