### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const app = express()
+const rateLimit = require('express-rate-limit')
 const port = process.env.port || 8080
 let session = require('express-session')
 const moment = require('moment')
@@ -232,7 +233,13 @@ app.get('/ping', async (req, res) => {
   }
 })
 app.use(keycloak.protect())
-app.post('/FOI-report', async (req, res) => {
+
+const foiReportLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+})
+
+app.post('/FOI-report', foiReportLimiter, async (req, res) => {
   if (req.body.downloadToken) {
     res.cookie('downloadToken', req.body.downloadToken)
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "vuetify": "^2.0.0",
     "vuetify-loader": "1.7.0",
     "webpack": "^5.76.0",
-    "yn": "^4.0.0"
+    "yn": "^4.0.0",
+    "express-rate-limit": "^7.5.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/foi-report-download/security/code-scanning/3](https://github.com/bcgov/foi-report-download/security/code-scanning/3)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. This middleware will limit the number of requests a client can make to the server within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `index.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the specific route handler that performs the database access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
