### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,12 @@ const pdfFonts = {
   },
 }
 
-app.get('/ping', async (req, res) => {
+const pingLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+})
+
+app.get('/ping', pingLimiter, async (req, res) => {
   try {
     const { rows } = await pool.query('SELECT $1::text as message', ['OK!'])
     res.end(rows[0].message)


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/foi-report-download/security/code-scanning/2](https://github.com/bcgov/foi-report-download/security/code-scanning/2)

To fix the problem, we need to add rate limiting to the `/ping` route handler. This can be achieved by using the `express-rate-limit` package, which is already imported in the code. We will create a rate limiter specifically for the `/ping` route and apply it to the route handler.

1. Define a new rate limiter for the `/ping` route.
2. Apply the rate limiter to the `/ping` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
